### PR TITLE
Fix typo

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@
 
 This project aims to further develop the concept of Public Code. More concretely: How should we understand Public Code, and how can we create it? What kind of technological and institutional arrangements are needed to shift towards the production of Public Code.
 
-In a series of workshop, we want to build a network of collaborators to identify directions for the development of public code, and set up research & development projects and grant applications.
+In a series of workshops, we want to build a network of collaborators to identify directions for the development of public code, and set up research & development projects and grant applications.
 
 «Smart Cities? Public Code!» is a collaboration between the City of Amsterdam, the Amsterdam University of Applied Sciences and Vurb.Agency.
 


### PR DESCRIPTION
→ changed singular to plural: “workshop” to “workshops"