### PR TITLE
Pin html-proofer ~> 3.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
-gem 'html-proofer'
+gem 'html-proofer', '~>3.19'
 gem 'mdl'


### PR DESCRIPTION
fix "htmlproofer 4.0.1 | Error:  invalid option: --typhoeus-config"

https://github.com/publiccodenet/projects/runs/7313705770?check_suite_focus=true