### PR TITLE
Add talks from Tallinn Digital Summit 2022

### DIFF
--- a/talks.md
+++ b/talks.md
@@ -7,6 +7,8 @@ Note: this is not a complete list of conference talks we've given.
 
 ## 2022
 
+- [Fireside: Tailored for Success: The Growing Potential of Digital Public Goods](https://www.digitalsummit.ee/programme/fireside-tailored-for-success-the-growing-potential-of-digital-public-goods), by Ben Cerveny at [Tallinn Digital Summit](ttps://www.digitalsummit.ee) [[video](https://youtu.be/mptmCfPWG6k?t=21011)] (October 2022)
+- [Panel: Trusted Solutions for a Digital Society: Digital Public Goods](https://www.digitalsummit.ee/programme/panel-trusted-solutions-for-a-digital-society-digital-public-goods), by Ben Cerveny at [Tallinn Digital Summit](ttps://www.digitalsummit.ee) [[video](https://youtu.be/mptmCfPWG6k?t=23203)] (October 2022)
 - [Standard for Public Code](https://www.ow2con.org/view/2022/Abstract_Community_Day#08061125), by Jan Ainali and Eric Herman at [OW2con'22](https://www.ow2con.org/view/2022/) [[slides](https://files.publiccode.net/nextcloud/index.php/s/HM47a44LwGGgQJY)] [[video](https://youtu.be/u0s2pzF9BFI?t=5337)] (June 2022)
 - [Standard for Public Code](https://eventyay.com/e/6b901f56/session/7645), by Eric Herman and Jan Ainali at [FOSSAsia Summit 2022](https://eventyay.com/e/6b901f56) [[video](https://www.youtube.com/watch?v=-U-sgeT_TOQ)], [[slides](https://files.publiccode.net/nextcloud/index.php/s/4Wn2wCbRbXwHdMH)] (April 2022)
 - [Future digital public infrastructure laboratory](https://schedule.mozillafestival.org/session/8L9VED-1), by Jan Ainali, Elena Findley-de Regt and Ben Cerveny at [MozFest](https://www.mozillafestival.org/) 2022 [[video](https://files.publiccode.net/nextcloud/index.php/s/sZSL2HRm7755JpG)], [[Miro board](https://miro.com/app/board/uXjVOHHg4yk=/)] (March 2022)


### PR DESCRIPTION
Fixes #115

-----
[View rendered talks.md](https://github.com/publiccodenet/projects/blob/tallinn-2022-talks/talks.md)